### PR TITLE
Support for API Gateway proxy resources

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ module.exports.router = () => ({
   options: (path, handler) => routes.add('OPTIONS', path, handler),
 
   route: (event, context, callback) => {
-    const resource = event.resource;
+    const proxyMatch = event.resource.match(/{[a-zA-Z0-9._\-]+\+}/);
+    const resource = proxyMatch ? event.resource.replace(proxyMatch[0], event.pathParameters[proxyMatch[0].slice(1, proxyMatch[0].length - 2)]) : event.resource;
     const httpMethod = event.httpMethod;
 
     const resolved = routes.find(httpMethod, resource);


### PR DESCRIPTION
Checks the event resource for a proxy resource {proxyName+} and if present, pulls the path from the pathParameters and plugs it into the resource.